### PR TITLE
Added Spy Creation and Names Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .env
+test.spec.ts
+test.ts

--- a/templates/test-component.ejs
+++ b/templates/test-component.ejs
@@ -6,9 +6,11 @@ mImp of multiList) { %> import { <% for (const m of mImp.import) { %> <%= m%>,
 let component: <%= className%>; let fixture: ComponentFixture<<%= className%>>;
 <%for (const declareSpy of declareSpyList) { %> let <%= declareSpy.var%>:
 jasmine.SpyObj<<%= declareSpy.type %>>; <% } %> beforeEach( waitForAsync(() => {
+<% for (const spy of spyMap.entries()) { %> const <%= spy[0]%>Spy =
+jasmine.createSpyObj('<%= spy[1].type%>' );<% } %>
 TestBed.configureTestingModule({ declarations: [<%= className%>], imports:
-[IonicModule.forRoot()], }).compileComponents(); fixture =
+[IonicModule.forRoot()], providers:[ ] }).compileComponents(); fixture =
 TestBed.createComponent(<%= className%>); component = fixture.componentInstance;
-fixture.detectChanges(); }) ); it('should create', () => {
+fixture.detectChanges(); })); it('should create', () => {
 expect(component).toBeTruthy(); }); <% for (const fnName of fnNames) { %>
 xit('<%= fnName %>',() => {}); <% } %> });


### PR DESCRIPTION
#Spy Creation:
1. Used javascript map to create a hash map for all dependencies and the methods used in the component
2. As of now the map as all the data we need to complete the spy creation but due to template issues, we are declaring the spy object. But the map can be used to generate the complete spy list.

# Names Fix: 
Due to certain nodes not having the name property, the process used to terminate without generating a file. Now even if a property is missing the script will move forward with the available information and generate the file. Although it causes certain imports to not be added. OR sometimes not declaring the required import. Will be fixing it separately.